### PR TITLE
Add GCP deployment scripts for Streamlit app

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ streamlit run src/dice_agent/streamlit_app.py
 Click the button to roll a dice and the app will report whether the number is
 prime.
 
+## Deployment on Google Cloud VM
+
+A helper script is included to spin up a small Compute Engine instance and
+run the Streamlit application automatically.  Ensure the gcloud CLI is
+installed and authenticated, then execute:
+
+```bash
+bash deploy/gcp_deploy.sh
+```
+
+Edit `deploy/gcp_deploy.sh` and `deploy/startup.sh` to supply your project ID,
+preferred zone and the Git repository URL.  Once the VM starts the interface
+will be accessible at `http://<EXTERNAL_IP>:8501`.
+
 ## Tests
 
 ```bash

--- a/deploy/gcp_deploy.sh
+++ b/deploy/gcp_deploy.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Simple deployment script to run the Streamlit app on a Google Compute Engine VM.
+#
+# Prerequisites:
+#   * The gcloud CLI must be installed and authenticated.
+#   * Replace the PROJECT_ID and REPO_URL variables below with your values.
+#
+# The script performs the following actions:
+#   1. Creates a firewall rule to allow inbound traffic to Streamlit's default port (8501).
+#   2. Creates a VM instance and attaches the startup script that installs and launches the app.
+#   3. After the instance starts, the application will be reachable via http://EXTERNAL_IP:8501.
+#
+# Usage:
+#   bash deploy/gcp_deploy.sh
+
+set -euo pipefail
+
+# ---- Configuration --------------------------------------------------------
+PROJECT_ID="your-gcp-project-id"   # ID of your GCP project
+ZONE="us-central1-a"               # Compute Engine zone to deploy in
+INSTANCE_NAME="dice-streamlit"     # Name for the VM instance
+MACHINE_TYPE="e2-micro"            # VM machine type
+
+# Optional: run gcloud in a specific project to avoid passing --project each time
+#gcloud config set project "$PROJECT_ID"
+
+# ---- Firewall -------------------------------------------------------------
+# Open TCP port 8501 so the Streamlit server can receive external traffic.  If
+# the firewall rule already exists, the command will fail.  "|| true" prevents
+# the script from stopping in that case.
+gcloud compute firewall-rules create allow-streamlit \
+    --project="$PROJECT_ID" \
+    --allow=tcp:8501 \
+    --target-tags=streamlit-server \
+    --description="Allow incoming HTTP traffic to Streamlit" || true
+
+# ---- VM Creation ----------------------------------------------------------
+# Create a Debian-based VM and attach our startup script.  The script performs
+# package installation and launches the app automatically on boot.
+gcloud compute instances create "$INSTANCE_NAME" \
+    --project="$PROJECT_ID" \
+    --zone="$ZONE" \
+    --machine-type="$MACHINE_TYPE" \
+    --tags=streamlit-server \
+    --image-family=debian-11 \
+    --image-project=debian-cloud \
+    --metadata-from-file startup-script=deploy/startup.sh
+
+# After a couple of minutes the app should be live.  Retrieve the external IP
+# with:
+#   gcloud compute instances describe "$INSTANCE_NAME" --zone "$ZONE" \
+#       --format='get(networkInterfaces[0].accessConfigs[0].natIP)'

--- a/deploy/startup.sh
+++ b/deploy/startup.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Startup script executed on the GCP VM.  It installs system and Python
+# dependencies, clones this repository, and launches the Streamlit app so it is
+# accessible from outside the instance.
+
+set -euo pipefail
+
+# ---- Configuration --------------------------------------------------------
+APP_DIR="/opt/dice_app"                       # Where to place the application
+REPO_URL="https://github.com/your-org/your-repo.git"  # Public Git repository URL
+
+# ---- System Setup ---------------------------------------------------------
+# Update package list and install Python, pip and Git.  These packages are
+# sufficient for running the Streamlit application.
+apt-get update
+apt-get install -y python3-pip git
+
+# ---- Application Code -----------------------------------------------------
+# Fetch the application source code from the repository.
+mkdir -p "$APP_DIR"
+cd "$APP_DIR"
+if [ ! -d repo ]; then
+    git clone "$REPO_URL" repo
+fi
+cd repo
+
+# ---- Python Dependencies --------------------------------------------------
+# Install required Python packages.  ``pip3`` is used instead of ``pip`` to
+# ensure the Python 3 version is invoked.
+pip3 install --upgrade pip
+pip3 install -r requirements.txt
+
+# ---- Run the Streamlit App -----------------------------------------------
+# Launch the Streamlit server.  ``--server.address 0.0.0.0`` makes the service
+# listen on all interfaces so it can be reached from the internet.  ``nohup``
+# keeps the process running after the startup script exits and redirects output
+# to a log file for later inspection.
+nohup streamlit run src/dice_agent/streamlit_app.py \
+    --server.address 0.0.0.0 \
+    --server.port 8501 \
+    > /var/log/streamlit.log 2>&1 &


### PR DESCRIPTION
## Summary
- add gcloud deployment script and VM startup script for Streamlit app
- document simple Compute Engine deployment in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ea5efe4548328adccbba626d84d30